### PR TITLE
Fix Symfony3 deprecated (and removed) arguments in services.xml

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -51,10 +51,8 @@
             </argument>
         </service>
 
-        <service id="seferov_aws.service"
-                 factory-method="get"
-                 factory-service="seferov_aws.service_factory"
-                 abstract="true">
+        <service id="seferov_aws.service" abstract="true">
+            <factory service="seferov_aws.service_factory" method="get" />
             <argument type="service" id="seferov_aws.credentials" />
         </service>
 


### PR DESCRIPTION
Resolves the warnings in Symfony 2.8 for me.