### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "~2.3|~3.0",
-        "aws/aws-sdk-php": "2.4.10"
+        "aws/aws-sdk-php": "~2.4"
     },
     "require-dev": {
         "symfony/finder": "2.6.*@dev|~3.0"


### PR DESCRIPTION
Allow more recent versions of aws-sdk-php package. This resolves a conflict for med with another package (sendgrid/sendgrid), as they both use guzzle as dependencies.