### PR TITLE
Symfony Kernel 2.5 can not parse service_factory_3.xml

### DIFF
--- a/DependencyInjection/SeferovAwsExtension.php
+++ b/DependencyInjection/SeferovAwsExtension.php
@@ -43,7 +43,7 @@ class SeferovAwsExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        if (Kernel::VERSION < 2.4) {
+        if (Kernel::VERSION < 2.6) {
             $loader->load('service_factory_2.3.xml');
         } else {
             $loader->load('service_factory_3.xml');


### PR DESCRIPTION
Kernel 2.5.10 give this error. It works with the applied change

> [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]                                                                      
  Unable to parse file "/vendor/seferov/aws-bundle/DependencyInjection/../Resources/config/service_factory_3.xml".