### PR TITLE
Update AWS SDK to version 3.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,6 +49,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('secret')->end()
                             ->scalarNode('region')->end()
                             ->scalarNode('profile')->end()
+                            ->scalarNode('version')->defaultValue('latest')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/SeferovAwsExtension.php
+++ b/DependencyInjection/SeferovAwsExtension.php
@@ -29,7 +29,7 @@ class SeferovAwsExtension extends Extension
     /**
      * @var array
      */
-    public $configKeys = array('key', 'secret', 'region', 'profile');
+    public $configKeys = array('key', 'secret', 'region', 'profile', 'version');
 
     /**
      * @param array            $configs
@@ -52,6 +52,9 @@ class SeferovAwsExtension extends Extension
         // Base config
         $baseConfig = array();
         foreach ($this->configKeys as $configKey) {
+            if ($configKey === 'version') {
+                continue 1;
+            }
             $baseConfig[$configKey] = array_key_exists($configKey, $config) && $config[$configKey] ? $config[$configKey] : null;
             $container->setParameter(self::SERVICE_NAMESPACE.'.'.$configKey, $config[$configKey]);
         }
@@ -65,7 +68,7 @@ class SeferovAwsExtension extends Extension
                     }
                 }
             } else {
-                $config['services'][$serviceKey] = $baseConfig;
+                $config['services'][$serviceKey] = array_merge($baseConfig, array('version' => 'latest'));
             }
 
             $container->setParameter(self::SERVICE_NAMESPACE.'.'.$serviceKey, $config['services'][$serviceKey]);

--- a/Entity/AwsCredentials.php
+++ b/Entity/AwsCredentials.php
@@ -47,6 +47,9 @@ class AwsCredentials
     {
         $serviceKey = ServicesHelper::camelcaseToUnderscore($service);
 
-        return $this->parameters[$serviceKey];
+        return $service
+            ? $this->parameters[$serviceKey]
+            : array_intersect_key($this->parameters, array_flip(array('key', 'secret', 'region')))
+        ;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -37,7 +37,6 @@
                 <argument key="sqs">%seferov_aws.sqs%</argument>
                 <argument key="s3">%seferov_aws.s3%</argument>
                 <argument key="swf">%seferov_aws.swf%</argument>
-                <argument key="simple_db">%seferov_aws.simple_db%</argument>
                 <argument key="auto_scaling">%seferov_aws.auto_scaling%</argument>
                 <argument key="cloud_formation">%seferov_aws.cloud_formation%</argument>
                 <argument key="cloud_trail">%seferov_aws.cloud_trail%</argument>
@@ -69,15 +68,15 @@
         <service id="aws.cloudWatchLogs" class="CloudWatchLogs" parent="seferov_aws.service">
             <argument>CloudWatchLogs</argument>
         </service>
-        
+
         <service id="aws.cognitoIdentity" class="CognitoIdentity" parent="seferov_aws.service">
             <argument>CognitoIdentity</argument>
         </service>
-        
+
         <service id="aws.cognitoSync" class="CognitoSync" parent="seferov_aws.service">
             <argument>CognitoSync</argument>
         </service>
-        
+
         <service id="aws.dynamoDb" class="DynamoDb" parent="seferov_aws.service">
             <argument>DynamoDb</argument>
         </service>
@@ -132,10 +131,6 @@
 
         <service id="aws.swf" class="Swf" parent="seferov_aws.service">
             <argument>Swf</argument>
-        </service>
-
-        <service id="aws.simpleDb" class="SimpleDb" parent="seferov_aws.service">
-            <argument>SimpleDb</argument>
         </service>
 
         <service id="aws.autoScaling" class="AutoScaling" parent="seferov_aws.service">

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -2,7 +2,9 @@
 
 Parameters can be set for each services seperately. If not set, general parameters at the top will be applied.
 
-Available services: CloudFront, CloudSearch, CloudWatch, CloudWatchLogs, CognitoIdentity, CognitoSync, DynamoDb, Ec2, Emr, ElasticTranscoder, ElastiCache, Glacier, Redshift, Rds, Route53, Ses, Sns, Sqs, S3, Swf, SimpleDb, AutoScaling, CloudFormation, CloudTrail, DataPipeline, DirectConnect, ElasticBeanstalk, Iam, ImportExport, OpsWorks, Sts, StorageGateway, Support, ElasticLoadBalancing
+Version parameter for each service defaults to 'latest'.  It is recommended by AWS that this not be depended on in a production environment, but set to one of the listed [API versions](http://docs.aws.amazon.com/aws-sdk-php/v3/api/).  There is no general version parameter as this value is different for each service.
+
+Available services: CloudFront, CloudSearch, CloudWatch, CloudWatchLogs, CognitoIdentity, CognitoSync, DynamoDb, Ec2, Emr, ElasticTranscoder, ElastiCache, Glacier, Redshift, Rds, Route53, Ses, Sns, Sqs, S3, Swf, AutoScaling, CloudFormation, CloudTrail, DataPipeline, DirectConnect, ElasticBeanstalk, Iam, ImportExport, OpsWorks, Sts, StorageGateway, Support, ElasticLoadBalancing
 
 ``` yaml
 seferov_aws:
@@ -14,9 +16,11 @@ seferov_aws:
             key: AWS_S3_KEY
             secret: AWS_S3_SECRET
             region: AWS_S3_REGION
+            version: AWS_S3_VERSION
         sqs:
             key: AWS_SQS_KEY
             secret: AWS_SQS_SECRET
             region: AWS_SQS_REGION
+            version: AWS_SQS_VERSION
         ...
 ```

--- a/Services/ServicesFactory.php
+++ b/Services/ServicesFactory.php
@@ -11,11 +11,11 @@
 
 namespace Seferov\AwsBundle\Services;
 
-use \Aws\Common\Aws;
+use \Aws\Sdk as Aws;
 use \Seferov\AwsBundle\Entity\AWSCredentials;
 
 /**
- * Factory class that initiates an AWS service.
+ * Factory class that initiates an AWS client.
  */
 class ServicesFactory
 {
@@ -43,7 +43,6 @@ class ServicesFactory
         'Sqs',
         'S3',
         'Swf',
-        'SimpleDb',
         'AutoScaling',
         'CloudFormation',
         'CloudTrail',
@@ -67,8 +66,8 @@ class ServicesFactory
      */
     public function get(AWSCredentials $AWSCredentials, $service)
     {
-        $aws = Aws::factory($AWSCredentials->getParameters($service));
+        $aws = new Aws($AWSCredentials->getParameters());
 
-        return $aws->get($service);
+        return $aws->createClient($service, $AWSCredentials->getParameters($service));
     }
 }

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -17,3 +17,8 @@ seferov_aws:
             key: ses_key
             secret: ses_secret
             region: 'us-east-1'
+        s3:
+            key: s3_key
+            secret: s3_secret
+            region: 'us-east-1'
+            version: '2006-03-01'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "aws/aws-sdk-php": "^3.19"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5",
+        "phpunit/phpunit": "^4.8",
         "symfony/finder": "2.6.*@dev|~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "symfony/symfony": "~2.3|~3.0",
-        "aws/aws-sdk-php": "^2.6.11"
+        "aws/aws-sdk-php": "^3.19"
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.5",
         "symfony/finder": "2.6.*@dev|~3.0"
     },
     "autoload": {


### PR DESCRIPTION
Adds API version configuration.  Removes SimpleDB service, though if needed to continue support, could possibly add the [AWS bridge package](https://github.com/aws/aws-sdk-php-v3-bridge).

Current stable PHPUnit requirement added for dev to allow testing with local ```./vendor/bin/phpunit```.